### PR TITLE
Add nextdns disguised third party trackers list

### DIFF
--- a/edit_here_to_add_blocklists.json
+++ b/edit_here_to_add_blocklists.json
@@ -1118,5 +1118,14 @@
         "totalDomains": 0,
         "lastUpdated": "",
         "value": 112
+    },
+    {
+        "loc":"custom_filters/normal/id113.txt",
+        "name": "nextdns (Disguised Third-Party Trackers)",
+        "category": "Privacy",
+        "source": "https://raw.githubusercontent.com/nextdns/cname-cloaking-blocklist/master/domains",
+        "totalDomains": 0,
+        "lastUpdated": "",
+        "value": 113
     }     
 ]


### PR DESCRIPTION
Tiny list but one that is available in the nextdns config and I think it could be useful here even though adguard cname tracker is likely to have some of these entries at least