### PR TITLE
More blocklist recommendations

### DIFF
--- a/edit_here_to_add_blocklists.json
+++ b/edit_here_to_add_blocklists.json
@@ -1172,5 +1172,41 @@
         "totalDomains": 0,
         "lastUpdated": "",
         "value": 118
+    },
+    {
+        "loc":"custom_filters/normal/id119.txt",
+        "name": "USOM (blacklist)",
+        "category": "Malware",
+        "source": "https://raw.githubusercontent.com/elliotwutingfeng/USOM-Blocklists/main/urls.txt",
+        "totalDomains": 0,
+        "lastUpdated": "",
+        "value": 119
+    },
+    {
+        "loc":"custom_filters/normal/id120.txt",
+        "name": "DuckDuckGo (Tracker Radar)",
+        "category": "Privacy",
+        "source": "https://blokada.org/blocklists/ddgtrackerradar/standard/hosts.txt",
+        "totalDomains": 0,
+        "lastUpdated": "",
+        "value": 120
+    },
+    {
+        "loc":"custom_filters/normal/id121.txt",
+        "name": "nextdns (recommended)",
+        "category": "Ads, Privacy, Malware",
+        "source": "https://raw.githubusercontent.com/cbuijs/accomplist/master/nextdns-recommended/plain.black.domain.list",
+        "totalDomains": 0,
+        "lastUpdated": "",
+        "value": 121
+    },
+    {
+        "loc":"custom_filters/normal/id122.txt",
+        "name": "rooneymcnibnug (SNAFU List)",
+        "category": "Ads, Privacy, Malware",
+        "source": "https://raw.githubusercontent.com/RooneyMcNibNug/pihole-stuff/master/SNAFU.txt",
+        "totalDomains": 0,
+        "lastUpdated": "",
+        "value": 122
     }    
 ]


### PR DESCRIPTION
USOM is made by the same person as Inversion but detects malware from Turkish feeds (or something like that). Duck duck go tracker radar is included with Blokada and this is one of the only lists that are not here that Blokada has. Nextdns recommended is 3 lists already included here combined but seems like a popular pick among nextdns users so it might be worth adding here anyways, RooneyMcNibNug’s SNAFU list is one that’s included on firebog and seems decent. 

These are the last lists i would recommend adding to dnswarden other than hagezi’s ultimate but we can wait a few weeks or months like you said👌.