### PR TITLE
Add HaGeZi Huawei and Windows with NextDNS’s list

### DIFF
--- a/edit_here_to_add_blocklists.json
+++ b/edit_here_to_add_blocklists.json
@@ -599,7 +599,7 @@
       "name": "NextDNS & HaGeZi (Huawei)",
       "category": "Wildcard",
       "url": ["https://raw.githubusercontent.com/nextdns/metadata/master/privacy/native/huawei",
-              "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/native.huawei.txt",
+              "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/native.huawei.txt"],
       "filterType": ["b-wild", "b-wild"],
       "source": "",
       "totalDomains": 0,

--- a/edit_here_to_add_blocklists.json
+++ b/edit_here_to_add_blocklists.json
@@ -596,19 +596,21 @@
       "value": 66
     },
     {
-      "name": "NextDNS (Huawei)",
+      "name": "NextDNS & HaGeZi (Huawei)",
       "category": "Wildcard",
-      "url": ["https://raw.githubusercontent.com/nextdns/metadata/master/privacy/native/huawei"],
-      "filterType": ["b-wild"],
+      "url": ["https://raw.githubusercontent.com/nextdns/metadata/master/privacy/native/huawei",
+              "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/native.huawei.txt",
+      "filterType": ["b-wild", "b-wild"],
       "source": "",
       "totalDomains": 0,
       "value": 67
     },
     {
-      "name": "NextDNS (Windows)",
+      "name": "NextDNS & HaGeZi (Windows)",
       "category": "Wildcard",
-      "url": ["https://raw.githubusercontent.com/nextdns/metadata/master/privacy/native/windows"],
-      "filterType": ["b-wild"],
+      "url": ["https://raw.githubusercontent.com/nextdns/metadata/master/privacy/native/windows",
+              "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/native.winoffice.txt"],
+      "filterType": ["b-wild","b-wild"],
       "source": "",
       "totalDomains": 0,
       "value": 68


### PR DESCRIPTION
Huawei seems to missing quite a few tracker entries and the windows one seems to missing a few also. These HaGeZi lists seem to cover the missed spaces